### PR TITLE
[fix]: 전역 객체 _mongo 타입 명시 (#2)

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,9 @@
+import { MongoClient } from 'mongodb';
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      _mongo: Promise<MongoClient>;
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -24,23 +20,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    "app/items/page.tsx",
-    "app/items/page.tsx",
-    "app/items/page.tsx",
-    "app/page.js",
-    "util/dbConnection.js"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 👀 이슈

resolve #2

## 📌 개요

프로젝트 빌드 시 컴파일러가 dbConnection.ts 파일 내 _mongo 객체의
타입을 인지하지 못 하는 문제가 있어서 해당 객체의 타입을 정의하였습니다.

## 👩‍💻 작업 사항

- 루트 디렉토리 `global.d.ts` 파일 추가
- `tsconfig.json` 파일 내 `include` 속성 값 수정

## ✅ 참고 사항

없습니다.